### PR TITLE
Feature/multiples dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ local-*
 *-local.*
 *-local
 
-.env
+.env*

--- a/README.md
+++ b/README.md
@@ -43,15 +43,16 @@ npm install
 ```
 
 ### 3. Configuración de variables de entorno
-Crear un archivo `.env` en la raíz del proyecto como se indica en las [instrucciones](/doc/DotEnvSetup.md).
-
+Crear un archivo `.env` / `.env.test` en la raíz del proyecto como se indica en las [instrucciones](/doc/DotEnvSetup.md).
+- `.env` se debe utilizar para producción.
+- `.env.test` se debe utilizar para testing.
 
 ## Pasos para correr el proyecto en local
 
 1. Iniciar el servidor:
 
 ```bash
-npm run server
+npm run server:test
 ```
 
 2. Abrir el navegador en la ruta indicada en la consola. Debería ser:
@@ -67,7 +68,7 @@ userRepo.createUser('[USERNAME]', '[PASSWORD]', '[NAME]', '[EMAIL]);
 ```
 al final del archivo [`/src/routes/routes.ts`](/src/routes/routes.ts).
 
-Luego inicial el servidor utilizando `npm run server`, se habrá creado un nuevo usuario de administrador con usuario [USERNAME] y contraseña [PASSWORD].
+Luego inicial el servidor utilizando `npm run server:test`, se habrá creado un nuevo usuario de administrador con usuario [USERNAME] y contraseña [PASSWORD].
 
 **Se recomienda eliminar la linea agregada después de usarla.**
 
@@ -81,8 +82,14 @@ npm run prepare
 
 * **Compilar el proyecto e iniciar el servidor**:
 
+Producción:
 ```bash
 npm run server
+```
+
+Testing:
+```bash
+npm run server:test
 ```
 
 ## Extra

--- a/doc/DotEnvSetup.md
+++ b/doc/DotEnvSetup.md
@@ -1,10 +1,16 @@
-Se deberá crear un archivo `.env` en la raíz del proyecto.
+Se deberá crear un archivo `.env` / `.env.test` en la raíz del proyecto.
 
 Las conexiones a la base de datos se pueden configurar de dos formas:
 1. Especificando las variables individuales: PGUSER, PGPASSWORD, PGHOST, PGPORT y PGDATABASE.
 2. Usando la variable DATABASE_URL con la cadena completa de conexión.
 
 En caso de que ambas configuraciones estén presentes, se priorizará el valor de DATABASE_URL.
+
+- El `.env` deberá tener las variables de entorno de la base de datos de producción.
+Cuando se ejecuta el servidor con `npm run server` se tomará el `.env`·
+
+- El `.env.test` deberá tener las variables de entorno de la base de datos de testing.
+Cuando se ejecuta el servidor con `npm run server:testing` se tomará el `.env.test`.
 
 Un ejemplo de archivo `.env` para correr localmente el proyecto:
 
@@ -15,6 +21,7 @@ PGHOST=localhost
 PGPORT=5432
 PGDATABASE=pyac_db
 
+SESSION_SECRET=[COMPLETAR]
 PORT=3000
 ```
 
@@ -25,5 +32,6 @@ Un ejemplo de `.env` donde se configura especificando la url de la base de datos
 ```
 DATABASE_URL=[URL]
 
+SESSION_SECRET=[COMPLETAR]
 PORT=3000
 ```

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "prepare": "tsc -p ./tsconfig.json",
-    "server": "npm run prepare && node dist/server"
+    "server": "npm run prepare && node dist/server",
+    "server:test": "NODE_ENV=testing npm run server"
   }
 }

--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -1,7 +1,8 @@
-import 'dotenv/config';
 import { Pool } from "pg";
 import type { ClientConfig } from "pg";
+import { dotenvConfig } from "../extra/dotenvConfig.js"
 
+dotenvConfig()
 
 const dbConfig: ClientConfig =
     process.env.DATABASE_URL

--- a/src/extra/dotenvConfig.ts
+++ b/src/extra/dotenvConfig.ts
@@ -1,0 +1,13 @@
+import dotenv from 'dotenv';
+import path from "path";
+
+export function dotenvConfig(){
+    let envFile = '.env'
+    if(process.env.NODE_ENV == 'testing'){
+        envFile = `.env.test`;
+    }
+    
+    console.log(`Using envFile = ${envFile}`)
+
+    dotenv.config({ path: path.resolve(process.cwd(), envFile) });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,9 +3,12 @@ import path from "path";
 import { fileURLToPath } from "url";
 import routes from "./routes/routes.js";
 import session from 'express-session';
+import { dotenvConfig } from "./extra/dotenvConfig.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+dotenvConfig()
 
 const app = express();
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
- El script para iniciar el servidor permite elegir si tomar las variables de ambiente desde `.env` ó desde `.env.test`.
- Actualiza la documentación con los nuevos cambios.

La configuración de que `.env` tomar queda encapsulada en la función `dotenvConfig`. La decisión la toma según el `NODE_ENV`.